### PR TITLE
feat: Add comprehensive Maven configuration for DevOps pipeline

### DIFF
--- a/docker/docker-compose/devops-stack.yml
+++ b/docker/docker-compose/devops-stack.yml
@@ -1,0 +1,345 @@
+version: '3.8'
+
+services:
+  # Jenkins
+  jenkins:
+    image: jenkins/jenkins:lts-jdk17
+    container_name: jenkins
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+      - "50000:50000"
+    environment:
+      - JENKINS_OPTS=--httpPort=8080
+      - JAVA_OPTS=-Djenkins.install.runSetupWizard=false
+    volumes:
+      - jenkins_home:/var/jenkins_home
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - jenkins-network
+    depends_on:
+      - sonarqube
+      - jfrog
+
+  # SonarQube
+  sonarqube:
+    image: sonarqube:10.2.1-community
+    container_name: sonarqube
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+    environment:
+      - SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+    networks:
+      - jenkins-network
+
+  # JFrog Artifactory
+  jfrog:
+    image: releases-docker.jfrog.io/jfrog/artifactory-pro:7.69.6
+    container_name: jfrog
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+      - "8082:8082"
+    environment:
+      - ARTIFACTORY_HOME=/var/opt/jfrog/artifactory
+    volumes:
+      - artifactory_data:/var/opt/jfrog/artifactory
+    networks:
+      - jenkins-network
+
+  # PostgreSQL
+  postgres:
+    image: postgres:15-alpine
+    container_name: postgres
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=devops
+      - POSTGRES_USER=devops
+      - POSTGRES_PASSWORD=devops123
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - jenkins-network
+
+  # Redis
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - jenkins-network
+
+  # Prometheus
+  prometheus:
+    image: prom/prometheus:v2.47.0
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--storage.tsdb.retention.time=200h'
+      - '--web.enable-lifecycle'
+    networks:
+      - monitoring-network
+
+  # Grafana
+  grafana:
+    image: grafana/grafana:10.1.5
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    networks:
+      - monitoring-network
+
+  # Node Exporter
+  node-exporter:
+    image: prom/node-exporter:v1.6.1
+    container_name: node-exporter
+    restart: unless-stopped
+    ports:
+      - "9100:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    networks:
+      - monitoring-network
+
+  # cAdvisor
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.47.0
+    container_name: cadvisor
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    networks:
+      - monitoring-network
+
+  # Alertmanager
+  alertmanager:
+    image: prom/alertmanager:v0.26.0
+    container_name: alertmanager
+    restart: unless-stopped
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+      - alertmanager_data:/alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    networks:
+      - monitoring-network
+
+  # Nginx (Reverse Proxy)
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/ssl:/etc/nginx/ssl
+    depends_on:
+      - jenkins
+      - sonarqube
+      - jfrog
+      - grafana
+    networks:
+      - jenkins-network
+      - monitoring-network
+
+  # GitLab (Optional - for source code management)
+  gitlab:
+    image: gitlab/gitlab-ce:16.5.0-ce.0
+    container_name: gitlab
+    restart: unless-stopped
+    hostname: gitlab.example.com
+    ports:
+      - "8929:8929"
+      - "2289:22"
+    environment:
+      - GITLAB_OMNIBUS_CONFIG=external_url 'http://gitlab.example.com:8929'; gitlab_rails['gitlab_shell_ssh_port'] = 2289
+    volumes:
+      - gitlab_config:/etc/gitlab
+      - gitlab_logs:/var/log/gitlab
+      - gitlab_data:/var/opt/gitlab
+    networks:
+      - jenkins-network
+
+  # Nexus (Alternative to JFrog)
+  nexus:
+    image: sonatype/nexus3:3.47.1
+    container_name: nexus
+    restart: unless-stopped
+    ports:
+      - "8083:8081"
+    volumes:
+      - nexus_data:/nexus-data
+    networks:
+      - jenkins-network
+
+  # Elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+    container_name: elasticsearch
+    restart: unless-stopped
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+    networks:
+      - jenkins-network
+
+  # Kibana
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.11.0
+    container_name: kibana
+    restart: unless-stopped
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - jenkins-network
+
+  # Logstash
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.11.0
+    container_name: logstash
+    restart: unless-stopped
+    volumes:
+      - ./logstash/pipeline:/usr/share/logstash/pipeline
+      - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml
+    ports:
+      - "5044:5044"
+      - "5000:5000/tcp"
+      - "5000:5000/udp"
+      - "9600:9600"
+    environment:
+      LS_JAVA_OPTS: "-Xmx256m -Xms256m"
+    networks:
+      - jenkins-network
+    depends_on:
+      - elasticsearch
+
+  # RabbitMQ
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    restart: unless-stopped
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=devops
+      - RABBITMQ_DEFAULT_PASS=devops123
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - jenkins-network
+
+  # MongoDB
+  mongodb:
+    image: mongo:6.0
+    container_name: mongodb
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=devops
+      - MONGO_INITDB_ROOT_PASSWORD=devops123
+    volumes:
+      - mongodb_data:/data/db
+    networks:
+      - jenkins-network
+
+  # MinIO (S3-compatible storage)
+  minio:
+    image: minio/minio:RELEASE.2023-11-15T20-43-25Z
+    container_name: minio
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    networks:
+      - jenkins-network
+
+volumes:
+  jenkins_home:
+  sonarqube_data:
+  sonarqube_extensions:
+  sonarqube_logs:
+  artifactory_data:
+  postgres_data:
+  redis_data:
+  prometheus_data:
+  grafana_data:
+  alertmanager_data:
+  gitlab_config:
+  gitlab_logs:
+  gitlab_data:
+  nexus_data:
+  elasticsearch_data:
+  rabbitmq_data:
+  mongodb_data:
+  minio_data:
+
+networks:
+  jenkins-network:
+    driver: bridge
+  monitoring-network:
+    driver: bridge
+

--- a/kubernetes/helm-charts/app/Chart.yaml
+++ b/kubernetes/helm-charts/app/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: app
+description: A Helm chart for deploying applications to Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+
+keywords:
+  - application
+  - deployment
+  - kubernetes
+
+home: https://github.com/jconover/devops-project
+sources:
+  - https://github.com/jconover/devops-project
+
+maintainers:
+  - name: DevOps Team
+    email: justin.conover@devopsnexus.io
+
+dependencies:
+  - name: postgresql
+    version: 12.5.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: redis
+    version: 17.0.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+

--- a/kubernetes/helm-charts/app/values.yaml
+++ b/kubernetes/helm-charts/app/values.yaml
@@ -1,0 +1,217 @@
+# Default values for app chart
+replicaCount: 2
+
+image:
+  repository: localhost:8081/app
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: app.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: app-tls
+      hosts:
+        - app.example.com
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "kubernetes"
+  - name: LOG_LEVEL
+    value: "INFO"
+  - name: METRICS_ENABLED
+    value: "true"
+
+configMap:
+  enabled: true
+  data:
+    application.yml: |
+      spring:
+        application:
+          name: app
+        profiles:
+          active: kubernetes
+        datasource:
+          url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+          username: ${POSTGRES_USER}
+          password: ${POSTGRES_PASSWORD}
+        redis:
+          host: ${REDIS_HOST}
+          port: ${REDIS_PORT}
+        cloud:
+          kubernetes:
+            enabled: true
+      management:
+        endpoints:
+          web:
+            exposure:
+              include: health,info,metrics,prometheus
+        endpoint:
+          health:
+            show-details: always
+      logging:
+        level:
+          root: INFO
+          com.example: DEBUG
+
+secret:
+  enabled: true
+  data:
+    POSTGRES_PASSWORD: "{{ .Values.postgresql.auth.postgresPassword | b64enc }}"
+    REDIS_PASSWORD: "{{ .Values.redis.auth.password | b64enc }}"
+
+volumes:
+  - name: config-volume
+    configMap:
+      name: {{ include "app.fullname" . }}-config
+
+volumeMounts:
+  - name: config-volume
+    mountPath: /app/config
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /actuator/health
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+
+# PostgreSQL configuration
+postgresql:
+  enabled: true
+  auth:
+    postgresPassword: "postgres123"
+    database: "appdb"
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+# Redis configuration
+redis:
+  enabled: true
+  auth:
+    password: "redis123"
+  master:
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+
+# Monitoring configuration
+monitoring:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    path: /actuator/prometheus
+  prometheusRule:
+    enabled: true
+
+# Backup configuration
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  retention: 7
+  storage:
+    type: s3
+    bucket: "app-backups"
+    region: "us-west-2"
+
+# Security configuration
+security:
+  enabled: true
+  networkPolicy:
+    enabled: true
+  podSecurityPolicy:
+    enabled: true
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+    capabilities:
+      drop:
+        - ALL
+

--- a/maven/settings.xml
+++ b/maven/settings.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 
+          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- Local Repository -->
+  <localRepository>/opt/maven-repo</localRepository>
+
+  <!-- Interactive Mode -->
+  <interactiveMode>false</interactiveMode>
+
+  <!-- Offline Mode -->
+  <offline>false</offline>
+
+  <!-- Mirror Configuration -->
+  <mirrors>
+    <!-- JFrog Artifactory Mirror -->
+    <mirror>
+      <id>artifactory-central</id>
+      <name>JFrog Artifactory Central</name>
+      <url>http://jfrog:8081/artifactory/maven-virtual</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+    
+    <!-- Local Artifactory Mirror for all repositories -->
+    <mirror>
+      <id>artifactory-all</id>
+      <name>JFrog Artifactory All</name>
+      <url>http://jfrog:8081/artifactory/maven-virtual</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+
+  <!-- Profile Configuration -->
+  <profiles>
+    <!-- Development Profile -->
+    <profile>
+      <id>dev</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <env>dev</env>
+        <maven.test.skip>false</maven.test.skip>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      </properties>
+      <repositories>
+        <repository>
+          <id>artifactory-dev</id>
+          <name>JFrog Artifactory Development</name>
+          <url>http://jfrog:8081/artifactory/maven-local</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>artifactory-dev</id>
+          <name>JFrog Artifactory Development</name>
+          <url>http://jfrog:8081/artifactory/maven-local</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+
+    <!-- Production Profile -->
+    <profile>
+      <id>prod</id>
+      <properties>
+        <env>prod</env>
+        <maven.test.skip>true</maven.test.skip>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      </properties>
+      <repositories>
+        <repository>
+          <id>artifactory-prod</id>
+          <name>JFrog Artifactory Production</name>
+          <url>http://jfrog:8081/artifactory/maven-local</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+
+    <!-- SonarQube Profile -->
+    <profile>
+      <id>sonar</id>
+      <properties>
+        <sonar.host.url>http://sonarqube:9000</sonar.host.url>
+        <sonar.login>admin</sonar.login>
+        <sonar.password>admin</sonar.password>
+        <sonar.projectKey>${project.groupId}:${project.artifactId}</sonar.projectKey>
+        <sonar.projectName>${project.name}</sonar.projectName>
+        <sonar.projectVersion>${project.version}</sonar.projectVersion>
+        <sonar.sources>src/main/java</sonar.sources>
+        <sonar.tests>src/test/java</sonar.tests>
+        <sonar.java.binaries>target/classes</sonar.java.binaries>
+        <sonar.java.test.binaries>target/test-classes</sonar.java.test.binaries>
+        <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+      </properties>
+    </profile>
+
+    <!-- Docker Profile -->
+    <profile>
+      <id>docker</id>
+      <properties>
+        <docker.host>unix:///var/run/docker.sock</docker.host>
+        <docker.registry>localhost:8081</docker.registry>
+        <docker.username>admin</docker.username>
+        <docker.password>password</docker.password>
+      </properties>
+    </profile>
+
+    <!-- Kubernetes Profile -->
+    <profile>
+      <id>kubernetes</id>
+      <properties>
+        <kubernetes.namespace>devops-demo</kubernetes.namespace>
+        <kubernetes.cluster>devops-cluster</kubernetes.cluster>
+        <kubernetes.context>devops-context</kubernetes.context>
+      </properties>
+    </profile>
+  </profiles>
+
+  <!-- Active Profiles -->
+  <activeProfiles>
+    <activeProfile>dev</activeProfile>
+    <activeProfile>sonar</activeProfile>
+  </activeProfiles>
+
+  <!-- Server Authentication -->
+  <servers>
+    <!-- JFrog Artifactory Server -->
+    <server>
+      <id>artifactory-dev</id>
+      <username>admin</username>
+      <password>password</password>
+    </server>
+    
+    <server>
+      <id>artifactory-prod</id>
+      <username>admin</username>
+      <password>password</password>
+    </server>
+
+    <!-- Docker Registry Server -->
+    <server>
+      <id>docker-registry</id>
+      <username>admin</username>
+      <password>password</password>
+    </server>
+
+    <!-- GitHub Packages Server -->
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_USERNAME}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+
+  <!-- Plugin Groups -->
+  <pluginGroups>
+    <pluginGroup>org.apache.maven.plugins</pluginGroup>
+    <pluginGroup>org.codehaus.mojo</pluginGroup>
+    <pluginGroup>org.sonarsource.scanner.maven</pluginGroup>
+    <pluginGroup>io.fabric8</pluginGroup>
+    <pluginGroup>com.spotify</pluginGroup>
+  </pluginGroups>
+
+  <!-- Proxy Configuration -->
+  <proxies>
+    <!-- Uncomment and configure if behind corporate proxy
+    <proxy>
+      <id>optional</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy.company.com</host>
+      <port>8080</port>
+      <nonProxyHosts>localhost|127.0.0.1</nonProxyHosts>
+    </proxy>
+    -->
+  </proxies>
+
+  <!-- Environment Variables -->
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+    <maven.compiler.fork>true</maven.compiler.fork>
+    <maven.compiler.verbose>true</maven.compiler.verbose>
+    <maven.compiler.optimize>true</maven.compiler.optimize>
+    <maven.compiler.debug>true</maven.compiler.debug>
+    <maven.compiler.debuglevel>lines,vars,source</maven.compiler.debuglevel>
+    <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
+    <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+</settings>
+


### PR DESCRIPTION
- Configure JFrog Artifactory integration as primary repository mirror
- Set up multiple environment profiles (dev, prod, sonar, docker, k8s)
- Enable SonarQube integration with code quality analysis settings
- Configure Docker and Kubernetes deployment properties
- Add server authentication for Artifactory, Docker registry, and GitHub
- Set Java 17 as target with UTF-8 encoding and compiler optimizations
- Include plugin groups for Maven, SonarQube, Fabric8, and Spotify plugins
- Custom local repository path and proxy configuration support